### PR TITLE
Switch from brs to brickadia-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-include = ["blank.brs"]
+include = ["reference.brs"]
 
 [dependencies]
 structopt = { version = "0.3", default-features = false }
-brs = { git = "https://github.com/Brickadia/brs", branch = "0.3" }
+brickadia = "0.1.12"
 tobj = "2.0"
 cgmath = "0.17"
 image = "0.23"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Currently only supports voxelization and simplification for BRS files.
 
 ```
 USAGE:
-    cargo run --release <file> <output> --bricktype <bricktype> --scale <scale> --simplify <simplify>
+    cargo run --release -- <file> <output> --bricktype <bricktype> --scale <scale> --simplify <simplify>
 ```
 
 The program supports two color modes when simplifying: lossless, and lossy. Lossless will prioritize color accuracy, while lossy will prioritize brick count.

--- a/src/barycentric.rs
+++ b/src/barycentric.rs
@@ -1,6 +1,10 @@
-use cgmath::{ Vector2, Vector3, InnerSpace };
+use cgmath::{InnerSpace, Vector2, Vector3};
 
-pub fn interpolate_uv(v: &[Vector3<f32>; 3], uv: &Option<[Vector2<f32>; 3]>, f: Vector3<f32>) -> Vector2<f32> {
+pub fn interpolate_uv(
+    v: &[Vector3<f32>; 3],
+    uv: &Option<[Vector2<f32>; 3]>,
+    f: Vector3<f32>,
+) -> Vector2<f32> {
     match uv {
         Some(uvs) => {
             let f0 = v[0] - f;
@@ -13,12 +17,12 @@ pub fn interpolate_uv(v: &[Vector3<f32>; 3], uv: &Option<[Vector2<f32>; 3]>, f: 
             let va2 = f0.cross(f1);
 
             let a = va.magnitude();
-            let a0 = va0.magnitude()/a * va.dot(va0).signum();
-            let a1 = va1.magnitude()/a * va.dot(va1).signum();
-            let a2 = va2.magnitude()/a * va.dot(va2).signum();
+            let a0 = va0.magnitude() / a * va.dot(va0).signum();
+            let a1 = va1.magnitude() / a * va.dot(va1).signum();
+            let a2 = va2.magnitude() / a * va.dot(va2).signum();
 
             uvs[0] * a0 + uvs[1] * a1 + uvs[2] * a2
-        },
-        None => Vector2::new(0., 0.)
+        }
+        None => Vector2::new(0., 0.),
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -9,99 +9,115 @@ pub fn float_equals(a: f32, b: f32) -> bool {
     (b - a).abs() < error_margin
 }
 
-pub fn rgb2hsv(rgb: Vector4::<u8>) -> Vector4::<f32> {
-	let r = (rgb[0] as f32)/255f32;
-	let g = (rgb[1] as f32)/255f32;
-    let b = (rgb[2] as f32)/255f32;
-    let a = (rgb[3] as f32)/255f32;
+pub fn rgb2hsv(rgb: Vector4<u8>) -> Vector4<f32> {
+    let r = (rgb[0] as f32) / 255f32;
+    let g = (rgb[1] as f32) / 255f32;
+    let b = (rgb[2] as f32) / 255f32;
+    let a = (rgb[3] as f32) / 255f32;
 
     // max of rgb is equivalent to V in HSV
     let mut max = r;
-    if g > max {max = g}
-    if b > max {max = b}
+    if g > max {
+        max = g
+    }
+    if b > max {
+        max = b
+    }
 
     // min of rgb is V - C where C is chroma (range)
     let mut min = r;
-    if g < min {min = g}
-    if b < min {min = b}
+    if g < min {
+        min = g
+    }
+    if b < min {
+        min = b
+    }
 
     let mid = max - min;
-    
+
     let mut hue = if float_equals(mid, 0f32) {
-		0f32
-	} else if float_equals(max, r) {
+        0f32
+    } else if float_equals(max, r) {
         modulus((g - b) / mid, 6f32)
-	} else if float_equals(max, g) {
-		(b - r) / mid + 2f32
-	} else if float_equals(max, b) {
-		(r - g) / mid + 4f32
-	} else {
+    } else if float_equals(max, g) {
+        (b - r) / mid + 2f32
+    } else if float_equals(max, b) {
+        (r - g) / mid + 4f32
+    } else {
         0f32
     };
 
     hue *= std::f32::consts::PI / 3f32;
-    if hue < 0f32 { hue += 2f32 * std::f32::consts::PI }
+    if hue < 0f32 {
+        hue += 2f32 * std::f32::consts::PI
+    }
 
     let saturation = if float_equals(max, 0f32) {
-		0f32
-	} else {
-		mid / max
-	};
+        0f32
+    } else {
+        mid / max
+    };
 
     Vector4::<f32>::new(hue, saturation, max, a)
 }
 
 fn color_conversion(color: u8) -> u8 {
-    if (color as f64/255.0) > 0.04045 { 
-        ((((color as f64/255.0) / 1.055) + 0.052_132_7).powf(2.4) * 255.0) as u8
+    if (color as f64 / 255.0) > 0.04045 {
+        ((((color as f64 / 255.0) / 1.055) + 0.052_132_7).powf(2.4) * 255.0) as u8
     } else {
-        ((color as f64/255.0) / 12.92 * 255.0) as u8
+        ((color as f64 / 255.0) / 12.92 * 255.0) as u8
     }
 }
 
-pub fn gamma_correct(rgb: Vector4::<u8>) -> Vector4::<u8> {
+pub fn gamma_correct(rgb: Vector4<u8>) -> Vector4<u8> {
     Vector4::<u8>::new(
         color_conversion(rgb[0]),
         color_conversion(rgb[1]),
-        color_conversion(rgb[2]), 
-        rgb[3])
+        color_conversion(rgb[2]),
+        rgb[3],
+    )
 }
 
-pub fn hsv2rgb(hsv: Vector4::<f32>) -> Vector4::<u8> {
+pub fn hsv2rgb(hsv: Vector4<f32>) -> Vector4<u8> {
     let hue = hsv[0] * 180f32 / std::f32::consts::PI;
     let saturation = hsv[1];
     let value = hsv[2];
 
     let chroma = value * saturation;
-    let x = chroma * (1f32 - (modulus(hue/60f32, 2f32) - 1f32).abs());
+    let x = chroma * (1f32 - (modulus(hue / 60f32, 2f32) - 1f32).abs());
     let match_value = value - chroma;
 
     let (r, g, b) = match hue {
-        hh if hh < 60f32  => (chroma, x, 0f32),
+        hh if hh < 60f32 => (chroma, x, 0f32),
         hh if hh < 120f32 => (x, chroma, 0f32),
         hh if hh < 180f32 => (0f32, chroma, x),
         hh if hh < 240f32 => (0f32, x, chroma),
         hh if hh < 300f32 => (x, 0f32, chroma),
         hh if hh < 360f32 => (chroma, 0f32, x),
-        _ => (0f32, 0f32, 0f32)
+        _ => (0f32, 0f32, 0f32),
     };
 
-    Vector4::new(((r + match_value)*255f32) as u8, ((g + match_value)*255f32) as u8, ((b + match_value)*255f32) as u8, (hsv[3]*255f32) as u8)
+    Vector4::new(
+        ((r + match_value) * 255f32) as u8,
+        ((g + match_value) * 255f32) as u8,
+        ((b + match_value) * 255f32) as u8,
+        (hsv[3] * 255f32) as u8,
+    )
 }
 
-pub fn hsv_distance(a: &Vector4::<f32>, b: &Vector4::<f32>) -> f32 {
+pub fn hsv_distance(a: &Vector4<f32>, b: &Vector4<f32>) -> f32 {
     // (a.x - b.x).powf(2.0) * 8./21.
     // + (a.y - b.y).powf(2.0) * 5./21.
     // + (a.z - b.z).powf(2.0) * 4./21.
     // + (a.w - b.w).powf(2.0) * 4./21.
 
-    (a.x.sin()*a.y - b.x.sin()*b.y).powf(2.0)
-    + (a.x.cos()*a.y - b.x.cos()*b.y).powf(2.0)
-    + (a.z - b.z).powf(2.0)
-    + (a.w - b.w).powf(2.0)
+    (a.x.sin() * a.y - b.x.sin() * b.y).powf(2.0)
+        + (a.x.cos() * a.y - b.x.cos() * b.y).powf(2.0)
+        + (a.z - b.z).powf(2.0)
+        + (a.w - b.w).powf(2.0)
 }
 
-pub fn hsv_average(colors: &[Vector4::<u8>]) -> Vector4::<f32> {
+pub fn hsv_average(colors: &[Vector4<u8>]) -> Vector4<f32> {
     let n = colors.len() as f32;
     let mut h_avg = 0f32;
     let mut s_avg = 0f32;
@@ -116,19 +132,19 @@ pub fn hsv_average(colors: &[Vector4::<u8>]) -> Vector4::<f32> {
         a_avg += color.w;
     }
 
-    Vector4::<f32>::new(h_avg/n, s_avg/n, v_avg/n, a_avg/n)
+    Vector4::<f32>::new(h_avg / n, s_avg / n, v_avg / n, a_avg / n)
 }
 
-pub fn convert_colorset_to_hsv(colorset: &[brs::Color]) -> Vec::<Vector4::<f32>> {
-    let mut new = Vec::<Vector4::<f32>>::with_capacity(colorset.len());
+pub fn convert_colorset_to_hsv(colorset: &[brickadia::save::Color]) -> Vec<Vector4<f32>> {
+    let mut new = Vec::<Vector4<f32>>::with_capacity(colorset.len());
     for c in colorset {
-        new.push(rgb2hsv(Vector4::new(c.r(), c.g(), c.b(), c.a())));
+        new.push(rgb2hsv(Vector4::new(c.r, c.g, c.b, c.a)));
     }
 
     new
 }
 
-pub fn match_hsv_to_colorset(colorset: &[Vector4::<f32>], color: &Vector4::<f32>) -> usize {
+pub fn match_hsv_to_colorset(colorset: &[Vector4<f32>], color: &Vector4<f32>) -> usize {
     let mut min = 0;
     let mut min_distance = hsv_distance(&colorset[0], &color);
     for (i, cs) in colorset.iter().enumerate() {

--- a/src/intersect.rs
+++ b/src/intersect.rs
@@ -1,70 +1,169 @@
-use cgmath::{ Vector3, InnerSpace };
+use cgmath::{InnerSpace, Vector3};
 
 fn find_min_max(f0: f32, f1: f32, f2: f32, min: &mut f32, max: &mut f32) {
-    *min = f0; *max = f0;
-    if *min > f1 { *min = f1 };
-    if *min > f2 { *min = f2 };
-    if *max < f1 { *max = f1 };
-    if *max < f2 { *max = f2 };
+    *min = f0;
+    *max = f0;
+    if *min > f1 {
+        *min = f1
+    };
+    if *min > f2 {
+        *min = f2
+    };
+    if *max < f1 {
+        *max = f1
+    };
+    if *max < f2 {
+        *max = f2
+    };
 }
 
 /*======================== X-tests ========================*/
 
-fn axis_test_x01(half_box: f32, v0: Vector3<f32>, v2: Vector3<f32>, a: f32, b: f32, fa: f32, fb: f32) -> bool {
-    let p0 = a*v0[1] - b*v0[2];
-    let p2 = a*v2[1] - b*v2[2];
-    let min: f32; let max: f32;
-    if p0 < p2 { min = p0; max = p2; } else { min = p2; max = p0; };
-    let rad = (fa + fb)*half_box;
+fn axis_test_x01(
+    half_box: f32,
+    v0: Vector3<f32>,
+    v2: Vector3<f32>,
+    a: f32,
+    b: f32,
+    fa: f32,
+    fb: f32,
+) -> bool {
+    let p0 = a * v0[1] - b * v0[2];
+    let p2 = a * v2[1] - b * v2[2];
+    let min: f32;
+    let max: f32;
+    if p0 < p2 {
+        min = p0;
+        max = p2;
+    } else {
+        min = p2;
+        max = p0;
+    };
+    let rad = (fa + fb) * half_box;
     !(min > rad || max < -rad)
 }
 
-fn axis_test_x2(half_box: f32, v0: Vector3<f32>, v1: Vector3<f32>, a: f32, b: f32, fa: f32, fb: f32) -> bool {
-    let p0 = a*v0[1] - b*v0[2];
-    let p1 = a*v1[1] - b*v1[2];
-    let min: f32; let max: f32;
-    if p0 < p1 { min = p0; max = p1; } else { min = p1; max = p0; };
-    let rad = (fa + fb)*half_box;
+fn axis_test_x2(
+    half_box: f32,
+    v0: Vector3<f32>,
+    v1: Vector3<f32>,
+    a: f32,
+    b: f32,
+    fa: f32,
+    fb: f32,
+) -> bool {
+    let p0 = a * v0[1] - b * v0[2];
+    let p1 = a * v1[1] - b * v1[2];
+    let min: f32;
+    let max: f32;
+    if p0 < p1 {
+        min = p0;
+        max = p1;
+    } else {
+        min = p1;
+        max = p0;
+    };
+    let rad = (fa + fb) * half_box;
     !(min > rad || max < -rad)
 }
 
 /*======================== Y-tests ========================*/
 
-fn axis_test_y02(half_box: f32, v0: Vector3<f32>, v2: Vector3<f32>, a: f32, b: f32, fa: f32, fb: f32) -> bool {
-    let p0 = - a*v0[0] + b*v0[2];
-    let p2 = - a*v2[0] + b*v2[2];
-    let min: f32; let max: f32;
-    if p0 < p2 { min = p0; max = p2; } else { min = p2; max = p0; };
-    let rad = (fa + fb)*half_box;
+fn axis_test_y02(
+    half_box: f32,
+    v0: Vector3<f32>,
+    v2: Vector3<f32>,
+    a: f32,
+    b: f32,
+    fa: f32,
+    fb: f32,
+) -> bool {
+    let p0 = -a * v0[0] + b * v0[2];
+    let p2 = -a * v2[0] + b * v2[2];
+    let min: f32;
+    let max: f32;
+    if p0 < p2 {
+        min = p0;
+        max = p2;
+    } else {
+        min = p2;
+        max = p0;
+    };
+    let rad = (fa + fb) * half_box;
     !(min > rad || max < -rad)
 }
 
-fn axis_test_y1(half_box: f32, v0: Vector3<f32>, v1: Vector3<f32>, a: f32, b: f32, fa: f32, fb: f32) -> bool {
-    let p0 = - a*v0[0] + b*v0[2];
-    let p1 = - a*v1[0] + b*v1[2];
-    let min: f32; let max: f32;
-    if p0 < p1 { min = p0; max = p1; } else { min = p1; max = p0; };
-    let rad = (fa + fb)*half_box;
+fn axis_test_y1(
+    half_box: f32,
+    v0: Vector3<f32>,
+    v1: Vector3<f32>,
+    a: f32,
+    b: f32,
+    fa: f32,
+    fb: f32,
+) -> bool {
+    let p0 = -a * v0[0] + b * v0[2];
+    let p1 = -a * v1[0] + b * v1[2];
+    let min: f32;
+    let max: f32;
+    if p0 < p1 {
+        min = p0;
+        max = p1;
+    } else {
+        min = p1;
+        max = p0;
+    };
+    let rad = (fa + fb) * half_box;
     !(min > rad || max < -rad)
 }
 
 /*======================== Z-tests ========================*/
 
-fn axis_test_z12(half_box: f32, v1: Vector3<f32>, v2: Vector3<f32>, a: f32, b: f32, fa: f32, fb: f32) -> bool {
-    let p1 = a*v1[0] - b*v1[1];
-    let p2 = a*v2[0] - b*v2[1];
-    let min: f32; let max: f32;
-    if p2 < p1 { min = p2; max = p1; } else { min = p1; max = p2; };
-    let rad = (fa + fb)*half_box;
+fn axis_test_z12(
+    half_box: f32,
+    v1: Vector3<f32>,
+    v2: Vector3<f32>,
+    a: f32,
+    b: f32,
+    fa: f32,
+    fb: f32,
+) -> bool {
+    let p1 = a * v1[0] - b * v1[1];
+    let p2 = a * v2[0] - b * v2[1];
+    let min: f32;
+    let max: f32;
+    if p2 < p1 {
+        min = p2;
+        max = p1;
+    } else {
+        min = p1;
+        max = p2;
+    };
+    let rad = (fa + fb) * half_box;
     !(min > rad || max < -rad)
 }
 
-fn axis_test_z0(half_box: f32, v0: Vector3<f32>, v1: Vector3<f32>, a: f32, b: f32, fa: f32, fb: f32) -> bool {
-    let p0 = a*v0[0] - b*v0[1];
-    let p1 = a*v1[0] - b*v1[1];
-    let min: f32; let max: f32;
-    if p0 < p1 { min = p0; max = p1; } else { min = p1; max = p0; };
-    let rad = (fa + fb)*half_box;
+fn axis_test_z0(
+    half_box: f32,
+    v0: Vector3<f32>,
+    v1: Vector3<f32>,
+    a: f32,
+    b: f32,
+    fa: f32,
+    fb: f32,
+) -> bool {
+    let p0 = a * v0[0] - b * v0[1];
+    let p1 = a * v1[0] - b * v1[1];
+    let min: f32;
+    let max: f32;
+    if p0 < p1 {
+        min = p0;
+        max = p1;
+    } else {
+        min = p1;
+        max = p0;
+    };
+    let rad = (fa + fb) * half_box;
     !(min > rad || max < -rad)
 }
 
@@ -72,7 +171,7 @@ fn plane_box_overlap(half_box: f32, normal: Vector3<f32>, vert: Vector3<f32>) ->
     let mut vmin = Vector3::<f32>::new(0.0, 0.0, 0.0);
     let mut vmax = Vector3::<f32>::new(0.0, 0.0, 0.0);
 
-    for q in 0 .. 3 {
+    for q in 0..3 {
         let v = vert[q];
         if normal[q] > 0.0 {
             vmin[q] = -half_box - v;
@@ -83,13 +182,23 @@ fn plane_box_overlap(half_box: f32, normal: Vector3<f32>, vert: Vector3<f32>) ->
         }
     }
 
-    if normal.dot(vmin) > 0.0 { return false };
-    if normal.dot(vmax) >= 0.0 { return true };
+    if normal.dot(vmin) > 0.0 {
+        return false;
+    };
+    if normal.dot(vmax) >= 0.0 {
+        return true;
+    };
 
     false
 }
 
-pub fn intersect(half_box: f32, center: Vector3<f32>, p0: Vector3<f32>, p1: Vector3<f32>, p2: Vector3<f32>) -> Option<Vector3::<f32>> {
+pub fn intersect(
+    half_box: f32,
+    center: Vector3<f32>,
+    p0: Vector3<f32>,
+    p1: Vector3<f32>,
+    p2: Vector3<f32>,
+) -> Option<Vector3<f32>> {
     let v0 = p0 - center;
     let v1 = p1 - center;
     let v2 = p2 - center;
@@ -99,32 +208,59 @@ pub fn intersect(half_box: f32, center: Vector3<f32>, p0: Vector3<f32>, p1: Vect
     let e2 = v0 - v2;
 
     let mut fe = Vector3::<f32>::new(e0[0].abs(), e0[1].abs(), e0[2].abs());
-    if !axis_test_x01(half_box, v0, v2, e0[2], e0[1], fe[2], fe[1]) { return None };
-    if !axis_test_y02(half_box, v0, v2, e0[2], e0[0], fe[2], fe[0]) { return None };
-    if !axis_test_z12(half_box, v1, v2, e0[1], e0[0], fe[1], fe[0]) { return None };
+    if !axis_test_x01(half_box, v0, v2, e0[2], e0[1], fe[2], fe[1]) {
+        return None;
+    };
+    if !axis_test_y02(half_box, v0, v2, e0[2], e0[0], fe[2], fe[0]) {
+        return None;
+    };
+    if !axis_test_z12(half_box, v1, v2, e0[1], e0[0], fe[1], fe[0]) {
+        return None;
+    };
 
     fe = Vector3::<f32>::new(e1[0].abs(), e1[1].abs(), e1[2].abs());
-    if !axis_test_x01(half_box, v0, v2, e1[2], e1[1], fe[2], fe[1]) { return None };
-    if !axis_test_y02(half_box, v0, v2, e1[2], e1[0], fe[2], fe[0]) { return None };
-    if !axis_test_z0(half_box, v0, v1, e1[1], e1[0], fe[1], fe[0]) { return None };
+    if !axis_test_x01(half_box, v0, v2, e1[2], e1[1], fe[2], fe[1]) {
+        return None;
+    };
+    if !axis_test_y02(half_box, v0, v2, e1[2], e1[0], fe[2], fe[0]) {
+        return None;
+    };
+    if !axis_test_z0(half_box, v0, v1, e1[1], e1[0], fe[1], fe[0]) {
+        return None;
+    };
 
     fe = Vector3::<f32>::new(e2[0].abs(), e2[1].abs(), e2[2].abs());
-    if !axis_test_x2(half_box, v0, v1, e2[2], e2[1], fe[2], fe[1]) { return None };
-    if !axis_test_y1(half_box, v0, v1, e2[2], e2[0], fe[2], fe[0]) { return None };
-    if !axis_test_z12(half_box, v1, v2, e2[1], e2[0], fe[1], fe[0]) { return None };
+    if !axis_test_x2(half_box, v0, v1, e2[2], e2[1], fe[2], fe[1]) {
+        return None;
+    };
+    if !axis_test_y1(half_box, v0, v1, e2[2], e2[0], fe[2], fe[0]) {
+        return None;
+    };
+    if !axis_test_z12(half_box, v1, v2, e2[1], e2[0], fe[1], fe[0]) {
+        return None;
+    };
 
-    let mut min: f32 = 0.0; let mut max: f32 = 0.0;
+    let mut min: f32 = 0.0;
+    let mut max: f32 = 0.0;
     find_min_max(v0[0], v1[0], v2[0], &mut min, &mut max);
-    if min > half_box || max < -half_box { return None };
+    if min > half_box || max < -half_box {
+        return None;
+    };
 
     find_min_max(v0[1], v1[1], v2[1], &mut min, &mut max);
-    if min > half_box || max < -half_box { return None };
+    if min > half_box || max < -half_box {
+        return None;
+    };
 
     find_min_max(v0[2], v1[2], v2[2], &mut min, &mut max);
-    if min > half_box || max < -half_box { return None };
+    if min > half_box || max < -half_box {
+        return None;
+    };
 
     let normal = e0.cross(e1);
-    if !plane_box_overlap(half_box, normal, v0) { return None };
+    if !plane_box_overlap(half_box, normal, v0) {
+        return None;
+    };
 
     // Orthogonal projection to determine UV coordinates
     Some((v0.dot(normal) * normal) / normal.dot(normal) + center)

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -1,12 +1,11 @@
+use cgmath::Vector3;
 /**
  * Copyright (C) 2014 Ben Foppa
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
-
 use std::mem;
-use cgmath::Vector3;
 
 pub struct VoxelTree<T> {
     pub size: u8,
@@ -20,11 +19,20 @@ pub enum TreeBody<T> {
     Branch(Box<Branches<T>>),
 }
 
-pub type Branches<T> = [TreeBody::<T>; 8];
+pub type Branches<T> = [TreeBody<T>; 8];
 
 impl<T> TreeBody<T> {
-    pub fn empty() -> Branches::<T> {
-        [TreeBody::Empty, TreeBody::Empty, TreeBody::Empty, TreeBody::Empty, TreeBody::Empty, TreeBody::Empty, TreeBody::Empty, TreeBody::Empty]
+    pub fn empty() -> Branches<T> {
+        [
+            TreeBody::Empty,
+            TreeBody::Empty,
+            TreeBody::Empty,
+            TreeBody::Empty,
+            TreeBody::Empty,
+            TreeBody::Empty,
+            TreeBody::Empty,
+            TreeBody::Empty,
+        ]
     }
 }
 
@@ -35,21 +43,19 @@ impl<T> VoxelTree<T> {
             contents: TreeBody::empty(),
         }
     }
-    
-    pub fn contains_bounds(&self, voxel: Vector3::<isize>) -> bool {
+
+    pub fn contains_bounds(&self, voxel: Vector3<isize>) -> bool {
         let high = 1 << self.size;
         let low = -high;
-        
+
         if voxel.x < low || voxel.y < low || voxel.z < low {
-            return false
+            return false;
         }
-        
-        (voxel.x + 1) <= high
-        && (voxel.y + 1) <= high
-        && (voxel.z + 1) <= high
+
+        (voxel.x + 1) <= high && (voxel.y + 1) <= high && (voxel.z + 1) <= high
     }
-    
-    pub fn grow_to_hold(&mut self, voxel: Vector3::<isize>) {
+
+    pub fn grow_to_hold(&mut self, voxel: Vector3<isize>) {
         while !self.contains_bounds(voxel) {
             self.size += 1;
 
@@ -73,7 +79,7 @@ impl<T> VoxelTree<T> {
             //                      |     |     |0|     |     |
             //                      |     |     |0|     |     |
             //                      ---------------------------
-            
+
             macro_rules! at(
                 ($c_idx:literal, $b_idx:literal) => {{
                     let mut branches = TreeBody::empty();
@@ -81,86 +87,106 @@ impl<T> VoxelTree<T> {
                     TreeBody::Branch(Box::new(branches))
                 }}
             );
-            
-            self.contents = [at!(0, 7), at!(1, 6), at!(2, 5), at!(3, 4), at!(4, 3), at!(5, 2), at!(6, 1), at!(7, 0)];
+
+            self.contents = [
+                at!(0, 7),
+                at!(1, 6),
+                at!(2, 5),
+                at!(3, 4),
+                at!(4, 3),
+                at!(5, 2),
+                at!(6, 1),
+                at!(7, 0),
+            ];
         }
     }
 
-    pub fn get_mut_or_create<'a>(&'a mut self, voxel: Vector3::<isize>) -> &'a mut TreeBody<T> {
+    pub fn get_mut_or_create<'a>(&'a mut self, voxel: Vector3<isize>) -> &'a mut TreeBody<T> {
         self.grow_to_hold(voxel);
         let mut m = 1 << self.size;
-        let mut branch = &mut self.contents[
-            (((voxel.x >= 0) as usize) << 2)
+        let mut branch = &mut self.contents[(((voxel.x >= 0) as usize) << 2)
             + (((voxel.y >= 0) as usize) << 1)
-            + (voxel.z >= 0) as usize
-        ];
-        
+            + (voxel.z >= 0) as usize];
+
         loop {
             m >>= 1;
-            if m == 0 { return branch }
+            if m == 0 {
+                return branch;
+            }
 
             let branch_id = ((((voxel.x & m) != 0) as usize) << 2)
-            + ((((voxel.y & m) != 0) as usize) << 1)
-            + ((voxel.z & m) != 0) as usize;
+                + ((((voxel.y & m) != 0) as usize) << 1)
+                + ((voxel.z & m) != 0) as usize;
 
             match branch {
                 TreeBody::Branch(b) => {
                     branch = &mut b[branch_id];
-                },
+                }
                 _ => {
                     // Make branch into a TreeBody::Branch if it isint
                     *branch = TreeBody::Branch(Box::new(TreeBody::empty()));
-                    
+
                     match branch {
                         TreeBody::Branch(b) => {
                             branch = &mut b[branch_id];
-                        },
-                        _ => unreachable!()
+                        }
+                        _ => unreachable!(),
                     }
                 }
             };
         }
     }
 
-    pub fn get_any_mut_or_create<'a>(&'a mut self) -> (Vector3::<isize>, &'a mut TreeBody<T>) {
+    pub fn get_any_mut_or_create<'a>(&'a mut self) -> (Vector3<isize>, &'a mut TreeBody<T>) {
         let mask = 1 << self.size;
         let voxel = Vector3::<isize>::new(-mask, -mask, -mask);
-        
+
         let branches = &mut self.contents;
         match VoxelTree::get_any_recursive(branches, mask, voxel) {
             Some(vector) => (vector, self.get_mut_or_create(vector)),
-            None => (voxel, self.get_mut_or_create(Vector3::<isize>::new(0, 0, 0)))
+            None => (
+                voxel,
+                self.get_mut_or_create(Vector3::<isize>::new(0, 0, 0)),
+            ),
         }
     }
 
-    fn get_any_recursive<'a>(branches: &'a mut Branches<T>, mask: isize, voxel: Vector3::<isize>) -> Option<Vector3::<isize>> {
+    fn get_any_recursive<'a>(
+        branches: &'a mut Branches<T>,
+        mask: isize,
+        voxel: Vector3<isize>,
+    ) -> Option<Vector3<isize>> {
         let m = mask >> 1;
 
         for (i, branch) in branches.iter_mut().enumerate() {
             let mut voxel_temp = voxel;
-            let step = 2*m + ((m == 0) as isize);
+            let step = 2 * m + ((m == 0) as isize);
             voxel_temp.x += step * ((i & 4) > 0) as isize;
             voxel_temp.y += step * ((i & 2) > 0) as isize;
             voxel_temp.z += step * ((i & 1) > 0) as isize;
 
             match branch {
                 TreeBody::Branch(b) => {
-                    if m == 0 { continue } // Dont recurse further
+                    if m == 0 {
+                        continue;
+                    } // Dont recurse further
 
                     let new_vector = VoxelTree::get_any_recursive(b, m, voxel_temp);
                     match new_vector {
                         Some(vector) => {
                             return Some(vector);
-                        },
+                        }
                         None => {
                             // No valid points in branch, clean up...
                             *branch = TreeBody::Empty;
                         }
                     }
-                },
+                }
                 TreeBody::Leaf(_) => {
-                    if m == 0 { return Some(voxel_temp) }
-                },
+                    if m == 0 {
+                        return Some(voxel_temp);
+                    }
+                }
                 TreeBody::Empty => {}
             }
         }

--- a/src/voxelize.rs
+++ b/src/voxelize.rs
@@ -1,28 +1,33 @@
-use crate::intersect::intersect;
 use crate::barycentric::interpolate_uv;
-use crate::octree::{ VoxelTree, TreeBody, Branches };
 use crate::color::*;
+use crate::intersect::intersect;
+use crate::octree::{Branches, TreeBody, VoxelTree};
 
 use tobj;
 
-use cgmath::{ Vector2, Vector3, Vector4 };
+use cgmath::{Vector2, Vector3, Vector4};
 use image::RgbaImage;
 
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
 struct Triangle {
-    material_id: Option::<usize>,
-    vertices: [Vector3::<f32>; 3],
-    uvs: Option::<[Vector2::<f32>; 3]>
+    material_id: Option<usize>,
+    vertices: [Vector3<f32>; 3],
+    uvs: Option<[Vector2<f32>; 3]>,
 }
 
-pub fn voxelize(models: &mut Vec::<tobj::Model>, materials: &[RgbaImage], scale: f32, bricktype: String) -> VoxelTree::<Vector4::<u8>> {
-    let mut octree = VoxelTree::<Vector4::<u8>>::new();
+pub fn voxelize(
+    models: &mut Vec<tobj::Model>,
+    materials: &[RgbaImage],
+    scale: f32,
+    bricktype: String,
+) -> VoxelTree<Vector4<u8>> {
+    let mut octree = VoxelTree::<Vector4<u8>>::new();
 
     // Determine model AABB to expand triangle octree to final size
     // Multiply y-coordinate by 2.5 to take into account plates
     let yscale = if bricktype == "micro" { 1.0 } else { 2.5 };
-    
+
     let u = &models[0].mesh.positions; // Guess initial
     let mut min = Vector3::new(u[0] * scale, u[1] * yscale * scale, u[2] * scale);
     let mut max = min;
@@ -30,20 +35,31 @@ pub fn voxelize(models: &mut Vec::<tobj::Model>, materials: &[RgbaImage], scale:
     for m in models.iter_mut() {
         let p = &mut m.mesh.positions;
         for v in (0..p.len()).step_by(3) {
-
             p[v] *= scale;
             p[v + 1] *= yscale * scale;
             p[v + 2] *= scale;
 
-            for m in 0 .. 3 {
-                if min[m] > p[v + m] { min[m] = p[v + m] };
-                if max[m] < p[v + m] { max[m] = p[v + m] };
+            for m in 0..3 {
+                if min[m] > p[v + m] {
+                    min[m] = p[v + m]
+                };
+                if max[m] < p[v + m] {
+                    max[m] = p[v + m]
+                };
             }
         }
     }
 
-    let floor_min = Vector3::<isize>::new(min[0].floor() as isize - 1, min[1].floor() as isize - 1, min[2].floor() as isize - 1);
-    let ceil_max = Vector3::<isize>::new(max[0].ceil() as isize + 1, max[1].ceil() as isize + 1, max[2].ceil() as isize + 1);
+    let floor_min = Vector3::<isize>::new(
+        min[0].floor() as isize - 1,
+        min[1].floor() as isize - 1,
+        min[2].floor() as isize - 1,
+    );
+    let ceil_max = Vector3::<isize>::new(
+        max[0].ceil() as isize + 1,
+        max[1].ceil() as isize + 1,
+        max[2].ceil() as isize + 1,
+    );
 
     while !octree.contains_bounds(floor_min) || !octree.contains_bounds(ceil_max) {
         octree.size += 1;
@@ -59,19 +75,31 @@ pub fn voxelize(models: &mut Vec::<tobj::Model>, materials: &[RgbaImage], scale:
         let material = mesh.material_id;
 
         for n in (0..mesh.indices.len()).step_by(3) {
-            let mut m = (3*mesh.indices[n]) as usize;
-            let v0 = Vector3::new(mesh.positions[m], mesh.positions[m + 1], mesh.positions[m + 2]);
-            m = (3*mesh.indices[n + 1]) as usize;
-            let v1 = Vector3::new(mesh.positions[m], mesh.positions[m + 1], mesh.positions[m + 2]);
-            m = (3*mesh.indices[n + 2]) as usize;
-            let v2 = Vector3::new(mesh.positions[m], mesh.positions[m + 1], mesh.positions[m + 2]);
+            let mut m = (3 * mesh.indices[n]) as usize;
+            let v0 = Vector3::new(
+                mesh.positions[m],
+                mesh.positions[m + 1],
+                mesh.positions[m + 2],
+            );
+            m = (3 * mesh.indices[n + 1]) as usize;
+            let v1 = Vector3::new(
+                mesh.positions[m],
+                mesh.positions[m + 1],
+                mesh.positions[m + 2],
+            );
+            m = (3 * mesh.indices[n + 2]) as usize;
+            let v2 = Vector3::new(
+                mesh.positions[m],
+                mesh.positions[m + 1],
+                mesh.positions[m + 2],
+            );
 
             let uvs = if !mesh.texcoords.is_empty() {
-                m = (2*mesh.indices[n]) as usize;
+                m = (2 * mesh.indices[n]) as usize;
                 let uv0 = Vector2::new(mesh.texcoords[m], mesh.texcoords[m + 1]);
-                m = (2*mesh.indices[n + 1]) as usize;
+                m = (2 * mesh.indices[n + 1]) as usize;
                 let uv1 = Vector2::new(mesh.texcoords[m], mesh.texcoords[m + 1]);
-                m = (2*mesh.indices[n + 2]) as usize;
+                m = (2 * mesh.indices[n + 2]) as usize;
                 let uv2 = Vector2::new(mesh.texcoords[m], mesh.texcoords[m + 1]);
 
                 Some([uv0, uv1, uv2])
@@ -82,7 +110,7 @@ pub fn voxelize(models: &mut Vec::<tobj::Model>, materials: &[RgbaImage], scale:
             let triangle = Triangle {
                 material_id: material,
                 vertices: [v0, v1, v2],
-                uvs
+                uvs,
             };
 
             triangles.push(triangle);
@@ -94,51 +122,68 @@ pub fn voxelize(models: &mut Vec::<tobj::Model>, materials: &[RgbaImage], scale:
     octree
 }
 
-fn recursive_voxelize<'a>(branches: &'a mut Branches<Vector4::<u8>>, mask: isize, vector: Vec::<Triangle>, materials: &[RgbaImage]) {
+fn recursive_voxelize<'a>(
+    branches: &'a mut Branches<Vector4<u8>>,
+    mask: isize,
+    vector: Vec<Triangle>,
+    materials: &[RgbaImage],
+) {
     let m = mask >> 1;
-    let half_box = (2*m + ((m == 0) as isize)) as f32 / 2.;
+    let half_box = (2 * m + ((m == 0) as isize)) as f32 / 2.;
 
     for (i, branch) in branches.iter_mut().enumerate() {
         if let TreeBody::Empty = branch {
             let center = Vector3::<f32>::new(
-                half_box * (2*((i & 4) > 0) as isize - 1) as f32,
-                half_box * (2*((i & 2) > 0) as isize - 1) as f32,
-                half_box * (2*((i & 1) > 0) as isize - 1) as f32
+                half_box * (2 * ((i & 4) > 0) as isize - 1) as f32,
+                half_box * (2 * ((i & 2) > 0) as isize - 1) as f32,
+                half_box * (2 * ((i & 1) > 0) as isize - 1) as f32,
             );
-        
+
             let mut triangles = Vec::<Triangle>::new();
-            let mut colors = Vec::<Vector4::<u8>>::new();
-        
+            let mut colors = Vec::<Vector4<u8>>::new();
+
             for triangle in &vector {
-                match intersect(half_box, center, triangle.vertices[0], triangle.vertices[1], triangle.vertices[2]) {
+                match intersect(
+                    half_box,
+                    center,
+                    triangle.vertices[0],
+                    triangle.vertices[1],
+                    triangle.vertices[2],
+                ) {
                     Some(intersection) => {
                         // Only calculate colors if in root level
                         if m == 0 {
                             if let Some(id) = triangle.material_id {
-                                let uv = interpolate_uv(&triangle.vertices, &triangle.uvs, intersection);
+                                let uv =
+                                    interpolate_uv(&triangle.vertices, &triangle.uvs, intersection);
                                 let m = &materials[id];
-                            
+
                                 let u = ((uv[0] - uv[0].floor()) * (m.width() - 1) as f32) as u32;
-                                let v = ((1. - uv[1] + uv[1].floor()) * (m.height() - 1) as f32) as u32;
-                            
+                                let v =
+                                    ((1. - uv[1] + uv[1].floor()) * (m.height() - 1) as f32) as u32;
+
                                 let c = *m.get_pixel(u, v);
-                                if c[3] == 0 { continue } // If alpha is zero, skeedaddle
+                                if c[3] == 0 {
+                                    continue;
+                                } // If alpha is zero, skeedaddle
                                 colors.push(Vector4::<u8>::new(c[0], c[1], c[2], c[3]));
                             }
                         }
-                    },
-                    None => { continue }
+                    }
+                    None => continue,
                 }
-        
+
                 let mut cloned_triangle = *triangle;
                 cloned_triangle.vertices[0] -= center;
                 cloned_triangle.vertices[1] -= center;
                 cloned_triangle.vertices[2] -= center;
-        
+
                 triangles.push(cloned_triangle);
             }
-        
-            if triangles.is_empty() { continue }
+
+            if triangles.is_empty() {
+                continue;
+            }
             if m != 0 {
                 // Not yet at root level, keep on recursing...
                 *branch = TreeBody::Branch(Box::new(TreeBody::empty()));


### PR DESCRIPTION
This PR removes `brs` as a dependency, in preference of `brickadia-rs`. Also, the reference BRS is largely ditched, with exception of the colorset, which could be included into the binary.